### PR TITLE
fix: include annotations in package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include benchmark_annotations/*

--- a/setup.py
+++ b/setup.py
@@ -5,4 +5,5 @@ import roadie
 setup(
     packages=find_packages(),
     version=roadie.infer_version("EFAAR-benchmarking"),
+    include_package_data=True,
 )


### PR DESCRIPTION
# What?

-   Adds a `MANIFEST.in` file to include annotations csvs when package is pip installed 

# Why?

-   See above
