### PR TITLE
chore: defer semantic versioning to setuptools-scm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools",
     "wheel",
-    "roadie",
+    "setuptools-scm[toml]>=3.4",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,6 @@
 from setuptools import find_packages, setup
 
-import roadie
-
 setup(
     packages=find_packages(),
-    version=roadie.infer_version("EFAAR-benchmarking"),
     include_package_data=True,
 )


### PR DESCRIPTION
# What?

-   Remove dependency of inner-source code in open-source project
-   Use `setuptools-scm` to automate semantic versioning

# Why?

-   This obviates the need for `roadie` in the packaging of this project
