### PR TITLE
chore: relock dependencies

### DIFF
--- a/requirements/dev_3.10.txt
+++ b/requirements/dev_3.10.txt
@@ -28,10 +28,6 @@ anyio==3.7.1
     #   fastapi
     #   jupyter-server
     #   starlette
-appnope==0.1.3
-    # via
-    #   ipykernel
-    #   ipython
 argon2-cffi==23.1.0
     # via jupyter-server
 argon2-cffi-bindings==21.2.0
@@ -91,9 +87,7 @@ cfgv==3.4.0
 chardet==5.2.0
     # via tox
 charset-normalizer==3.3.1
-    # via
-    #   aiohttp
-    #   requests
+    # via requests
 chex==0.1.8
     # via
     #   optax
@@ -165,6 +159,7 @@ filelock==3.12.4
     # via
     #   torch
     #   tox
+    #   triton
     #   virtualenv
 flake8==6.1.0
     # via efaar-benchmarking (pyproject.toml)
@@ -467,6 +462,37 @@ numpy==1.26.1
     #   xarray
 numpyro==0.13.2
     # via scvi-tools
+nvidia-cublas-cu12==12.1.3.1
+    # via
+    #   nvidia-cudnn-cu12
+    #   nvidia-cusolver-cu12
+    #   torch
+nvidia-cuda-cupti-cu12==12.1.105
+    # via torch
+nvidia-cuda-nvrtc-cu12==12.1.105
+    # via torch
+nvidia-cuda-runtime-cu12==12.1.105
+    # via torch
+nvidia-cudnn-cu12==8.9.2.26
+    # via torch
+nvidia-cufft-cu12==11.0.2.54
+    # via torch
+nvidia-curand-cu12==10.3.2.106
+    # via torch
+nvidia-cusolver-cu12==11.4.5.107
+    # via torch
+nvidia-cusparse-cu12==12.1.0.106
+    # via
+    #   nvidia-cusolver-cu12
+    #   torch
+nvidia-nccl-cu12==2.18.1
+    # via torch
+nvidia-nvjitlink-cu12==12.3.101
+    # via
+    #   nvidia-cusolver-cu12
+    #   nvidia-cusparse-cu12
+nvidia-nvtx-cu12==12.1.105
+    # via torch
 oauthlib==3.2.2
     # via requests-oauthlib
 opt-einsum==3.3.0
@@ -767,6 +793,8 @@ stevedore==5.1.0
     # via bandit
 sympy==1.12
     # via torch
+tbb==2021.11.0
+    # via umap-learn
 tensorstore==0.1.46
     # via
     #   flax
@@ -842,6 +870,8 @@ traitlets==5.11.2
     #   nbclient
     #   nbconvert
     #   nbformat
+triton==2.1.0
+    # via torch
 trove-classifiers==2023.10.18
     # via validate-pyproject
 types-pkg-resources==0.1.3

--- a/requirements/dev_3.11.txt
+++ b/requirements/dev_3.11.txt
@@ -28,10 +28,6 @@ anyio==3.7.1
     #   fastapi
     #   jupyter-server
     #   starlette
-appnope==0.1.3
-    # via
-    #   ipykernel
-    #   ipython
 argon2-cffi==23.1.0
     # via jupyter-server
 argon2-cffi-bindings==21.2.0
@@ -46,8 +42,6 @@ asttokens==2.4.0
     # via stack-data
 async-lru==2.0.4
     # via jupyterlab
-async-timeout==4.0.3
-    # via aiohttp
 attrs==23.1.0
     # via
     #   aiohttp
@@ -91,9 +85,7 @@ cfgv==3.4.0
 chardet==5.2.0
     # via tox
 charset-normalizer==3.3.1
-    # via
-    #   aiohttp
-    #   requests
+    # via requests
 chex==0.1.8
     # via
     #   optax
@@ -159,6 +151,7 @@ filelock==3.12.4
     # via
     #   torch
     #   tox
+    #   triton
     #   virtualenv
 flake8==6.1.0
     # via efaar-benchmarking (pyproject.toml)
@@ -461,6 +454,37 @@ numpy==1.26.1
     #   xarray
 numpyro==0.13.2
     # via scvi-tools
+nvidia-cublas-cu12==12.1.3.1
+    # via
+    #   nvidia-cudnn-cu12
+    #   nvidia-cusolver-cu12
+    #   torch
+nvidia-cuda-cupti-cu12==12.1.105
+    # via torch
+nvidia-cuda-nvrtc-cu12==12.1.105
+    # via torch
+nvidia-cuda-runtime-cu12==12.1.105
+    # via torch
+nvidia-cudnn-cu12==8.9.2.26
+    # via torch
+nvidia-cufft-cu12==11.0.2.54
+    # via torch
+nvidia-curand-cu12==10.3.2.106
+    # via torch
+nvidia-cusolver-cu12==11.4.5.107
+    # via torch
+nvidia-cusparse-cu12==12.1.0.106
+    # via
+    #   nvidia-cusolver-cu12
+    #   torch
+nvidia-nccl-cu12==2.18.1
+    # via torch
+nvidia-nvjitlink-cu12==12.3.101
+    # via
+    #   nvidia-cusolver-cu12
+    #   nvidia-cusparse-cu12
+nvidia-nvtx-cu12==12.1.105
+    # via torch
 oauthlib==3.2.2
     # via requests-oauthlib
 opt-einsum==3.3.0
@@ -761,6 +785,8 @@ stevedore==5.1.0
     # via bandit
 sympy==1.12
     # via torch
+tbb==2021.11.0
+    # via umap-learn
 tensorstore==0.1.46
     # via
     #   flax
@@ -825,6 +851,8 @@ traitlets==5.11.2
     #   nbclient
     #   nbconvert
     #   nbformat
+triton==2.1.0
+    # via torch
 trove-classifiers==2023.10.18
     # via validate-pyproject
 types-pkg-resources==0.1.3

--- a/requirements/dev_3.9.txt
+++ b/requirements/dev_3.9.txt
@@ -28,10 +28,6 @@ anyio==3.7.1
     #   fastapi
     #   jupyter-server
     #   starlette
-appnope==0.1.3
-    # via
-    #   ipykernel
-    #   ipython
 argon2-cffi==23.1.0
     # via jupyter-server
 argon2-cffi-bindings==21.2.0
@@ -91,9 +87,7 @@ cfgv==3.4.0
 chardet==5.2.0
     # via tox
 charset-normalizer==3.3.1
-    # via
-    #   aiohttp
-    #   requests
+    # via requests
 chex==0.1.8
     # via
     #   optax
@@ -165,6 +159,7 @@ filelock==3.12.4
     # via
     #   torch
     #   tox
+    #   triton
     #   virtualenv
 flake8==6.1.0
     # via efaar-benchmarking (pyproject.toml)
@@ -477,6 +472,37 @@ numpy==1.26.1
     #   xarray
 numpyro==0.13.2
     # via scvi-tools
+nvidia-cublas-cu12==12.1.3.1
+    # via
+    #   nvidia-cudnn-cu12
+    #   nvidia-cusolver-cu12
+    #   torch
+nvidia-cuda-cupti-cu12==12.1.105
+    # via torch
+nvidia-cuda-nvrtc-cu12==12.1.105
+    # via torch
+nvidia-cuda-runtime-cu12==12.1.105
+    # via torch
+nvidia-cudnn-cu12==8.9.2.26
+    # via torch
+nvidia-cufft-cu12==11.0.2.54
+    # via torch
+nvidia-curand-cu12==10.3.2.106
+    # via torch
+nvidia-cusolver-cu12==11.4.5.107
+    # via torch
+nvidia-cusparse-cu12==12.1.0.106
+    # via
+    #   nvidia-cusolver-cu12
+    #   torch
+nvidia-nccl-cu12==2.18.1
+    # via torch
+nvidia-nvjitlink-cu12==12.3.101
+    # via
+    #   nvidia-cusolver-cu12
+    #   nvidia-cusparse-cu12
+nvidia-nvtx-cu12==12.1.105
+    # via torch
 oauthlib==3.2.2
     # via requests-oauthlib
 opt-einsum==3.3.0
@@ -777,6 +803,8 @@ stevedore==5.1.0
     # via bandit
 sympy==1.12
     # via torch
+tbb==2021.11.0
+    # via umap-learn
 tensorstore==0.1.46
     # via
     #   flax
@@ -852,6 +880,8 @@ traitlets==5.11.2
     #   nbclient
     #   nbconvert
     #   nbformat
+triton==2.1.0
+    # via torch
 trove-classifiers==2023.10.18
     # via validate-pyproject
 types-pkg-resources==0.1.3

--- a/requirements/main_3.10.txt
+++ b/requirements/main_3.10.txt
@@ -53,9 +53,7 @@ cachetools==5.3.1
 certifi==2023.7.22
     # via requests
 charset-normalizer==3.3.1
-    # via
-    #   aiohttp
-    #   requests
+    # via requests
 chex==0.1.8
     # via
     #   optax
@@ -94,7 +92,9 @@ fastapi==0.104.0
     #   lightning
     #   lightning-cloud
 filelock==3.12.4
-    # via torch
+    # via
+    #   torch
+    #   triton
 flax==0.7.4
     # via scvi-tools
 fonttools==4.43.1
@@ -293,6 +293,37 @@ numpy==1.26.1
     #   xarray
 numpyro==0.13.2
     # via scvi-tools
+nvidia-cublas-cu12==12.1.3.1
+    # via
+    #   nvidia-cudnn-cu12
+    #   nvidia-cusolver-cu12
+    #   torch
+nvidia-cuda-cupti-cu12==12.1.105
+    # via torch
+nvidia-cuda-nvrtc-cu12==12.1.105
+    # via torch
+nvidia-cuda-runtime-cu12==12.1.105
+    # via torch
+nvidia-cudnn-cu12==8.9.2.26
+    # via torch
+nvidia-cufft-cu12==11.0.2.54
+    # via torch
+nvidia-curand-cu12==10.3.2.106
+    # via torch
+nvidia-cusolver-cu12==11.4.5.107
+    # via torch
+nvidia-cusparse-cu12==12.1.0.106
+    # via
+    #   nvidia-cusolver-cu12
+    #   torch
+nvidia-nccl-cu12==2.18.1
+    # via torch
+nvidia-nvjitlink-cu12==12.3.101
+    # via
+    #   nvidia-cusolver-cu12
+    #   nvidia-cusparse-cu12
+nvidia-nvtx-cu12==12.1.105
+    # via torch
 oauthlib==3.2.2
     # via requests-oauthlib
 opt-einsum==3.3.0
@@ -481,6 +512,8 @@ stdlib-list==0.9.0
     # via session-info
 sympy==1.12
     # via torch
+tbb==2021.11.0
+    # via umap-learn
 tensorstore==0.1.46
     # via
     #   flax
@@ -514,6 +547,8 @@ tqdm==4.66.1
     #   umap-learn
 traitlets==5.11.2
     # via lightning
+triton==2.1.0
+    # via torch
 types-python-dateutil==2.8.19.14
     # via arrow
 typing-extensions==4.8.0

--- a/requirements/main_3.11.txt
+++ b/requirements/main_3.11.txt
@@ -31,8 +31,6 @@ array-api-compat==1.4
     # via anndata
 arrow==1.3.0
     # via lightning
-async-timeout==4.0.3
-    # via aiohttp
 attrs==23.1.0
     # via aiohttp
 backoff==2.2.1
@@ -53,9 +51,7 @@ cachetools==5.3.1
 certifi==2023.7.22
     # via requests
 charset-normalizer==3.3.1
-    # via
-    #   aiohttp
-    #   requests
+    # via requests
 chex==0.1.8
     # via
     #   optax
@@ -90,7 +86,9 @@ fastapi==0.104.0
     #   lightning
     #   lightning-cloud
 filelock==3.12.4
-    # via torch
+    # via
+    #   torch
+    #   triton
 flax==0.7.4
     # via scvi-tools
 fonttools==4.43.1
@@ -289,6 +287,37 @@ numpy==1.26.1
     #   xarray
 numpyro==0.13.2
     # via scvi-tools
+nvidia-cublas-cu12==12.1.3.1
+    # via
+    #   nvidia-cudnn-cu12
+    #   nvidia-cusolver-cu12
+    #   torch
+nvidia-cuda-cupti-cu12==12.1.105
+    # via torch
+nvidia-cuda-nvrtc-cu12==12.1.105
+    # via torch
+nvidia-cuda-runtime-cu12==12.1.105
+    # via torch
+nvidia-cudnn-cu12==8.9.2.26
+    # via torch
+nvidia-cufft-cu12==11.0.2.54
+    # via torch
+nvidia-curand-cu12==10.3.2.106
+    # via torch
+nvidia-cusolver-cu12==11.4.5.107
+    # via torch
+nvidia-cusparse-cu12==12.1.0.106
+    # via
+    #   nvidia-cusolver-cu12
+    #   torch
+nvidia-nccl-cu12==2.18.1
+    # via torch
+nvidia-nvjitlink-cu12==12.3.101
+    # via
+    #   nvidia-cusolver-cu12
+    #   nvidia-cusparse-cu12
+nvidia-nvtx-cu12==12.1.105
+    # via torch
 oauthlib==3.2.2
     # via requests-oauthlib
 opt-einsum==3.3.0
@@ -477,6 +506,8 @@ stdlib-list==0.9.0
     # via session-info
 sympy==1.12
     # via torch
+tbb==2021.11.0
+    # via umap-learn
 tensorstore==0.1.46
     # via
     #   flax
@@ -510,6 +541,8 @@ tqdm==4.66.1
     #   umap-learn
 traitlets==5.11.2
     # via lightning
+triton==2.1.0
+    # via torch
 types-python-dateutil==2.8.19.14
     # via arrow
 typing-extensions==4.8.0

--- a/requirements/main_3.9.txt
+++ b/requirements/main_3.9.txt
@@ -53,9 +53,7 @@ cachetools==5.3.1
 certifi==2023.7.22
     # via requests
 charset-normalizer==3.3.1
-    # via
-    #   aiohttp
-    #   requests
+    # via requests
 chex==0.1.8
     # via
     #   optax
@@ -94,7 +92,9 @@ fastapi==0.104.0
     #   lightning
     #   lightning-cloud
 filelock==3.12.4
-    # via torch
+    # via
+    #   torch
+    #   triton
 flax==0.7.4
     # via scvi-tools
 fonttools==4.43.1
@@ -297,6 +297,37 @@ numpy==1.26.1
     #   xarray
 numpyro==0.13.2
     # via scvi-tools
+nvidia-cublas-cu12==12.1.3.1
+    # via
+    #   nvidia-cudnn-cu12
+    #   nvidia-cusolver-cu12
+    #   torch
+nvidia-cuda-cupti-cu12==12.1.105
+    # via torch
+nvidia-cuda-nvrtc-cu12==12.1.105
+    # via torch
+nvidia-cuda-runtime-cu12==12.1.105
+    # via torch
+nvidia-cudnn-cu12==8.9.2.26
+    # via torch
+nvidia-cufft-cu12==11.0.2.54
+    # via torch
+nvidia-curand-cu12==10.3.2.106
+    # via torch
+nvidia-cusolver-cu12==11.4.5.107
+    # via torch
+nvidia-cusparse-cu12==12.1.0.106
+    # via
+    #   nvidia-cusolver-cu12
+    #   torch
+nvidia-nccl-cu12==2.18.1
+    # via torch
+nvidia-nvjitlink-cu12==12.3.101
+    # via
+    #   nvidia-cusolver-cu12
+    #   nvidia-cusparse-cu12
+nvidia-nvtx-cu12==12.1.105
+    # via torch
 oauthlib==3.2.2
     # via requests-oauthlib
 opt-einsum==3.3.0
@@ -485,6 +516,8 @@ stdlib-list==0.9.0
     # via session-info
 sympy==1.12
     # via torch
+tbb==2021.11.0
+    # via umap-learn
 tensorstore==0.1.46
     # via
     #   flax
@@ -518,6 +551,8 @@ tqdm==4.66.1
     #   umap-learn
 traitlets==5.11.2
     # via lightning
+triton==2.1.0
+    # via torch
 types-python-dateutil==2.8.19.14
     # via arrow
 typing-extensions==4.8.0


### PR DESCRIPTION
# What?
lock dependencies
# Why?
Monthly maintenace
# Notes:
```

python
	 version: 3.9.14
	location: /usr/local/bin/python
roadie
	 version: 6.4.1
	location: /usr/local/lib/python3.9/site-packages/roadie
✓ Retrieving roadie-enabled Python interpreters
Found roadie for the following Python versions: 3.7, 3.8, 3.9, 3.10, 3.11
✓ Attempting to lock for Python 3.9
✓ Attempting to lock for Python 3.11
✓ Attempting to lock for Python 3.10
Skipping Python 3.8
Skipping Python 3.7

```