### PR TITLE
chore: relock dependencies

### DIFF
--- a/requirements/dev_3.10.txt
+++ b/requirements/dev_3.10.txt
@@ -23,8 +23,6 @@ anndata==0.10.3
     #   scvi-tools
 anyio==4.2.0
     # via jupyter-server
-appnope==0.1.3
-    # via ipykernel
 argon2-cffi==23.1.0
     # via jupyter-server
 argon2-cffi-bindings==21.2.0
@@ -128,6 +126,7 @@ filelock==3.13.1
     # via
     #   torch
     #   tox
+    #   triton
     #   virtualenv
 flake8==6.1.0
     # via efaar_benchmarking (pyproject.toml)
@@ -422,6 +421,37 @@ numpy==1.26.2
     #   xarray
 numpyro==0.13.2
     # via scvi-tools
+nvidia-cublas-cu12==12.1.3.1
+    # via
+    #   nvidia-cudnn-cu12
+    #   nvidia-cusolver-cu12
+    #   torch
+nvidia-cuda-cupti-cu12==12.1.105
+    # via torch
+nvidia-cuda-nvrtc-cu12==12.1.105
+    # via torch
+nvidia-cuda-runtime-cu12==12.1.105
+    # via torch
+nvidia-cudnn-cu12==8.9.2.26
+    # via torch
+nvidia-cufft-cu12==11.0.2.54
+    # via torch
+nvidia-curand-cu12==10.3.2.106
+    # via torch
+nvidia-cusolver-cu12==11.4.5.107
+    # via torch
+nvidia-cusparse-cu12==12.1.0.106
+    # via
+    #   nvidia-cusolver-cu12
+    #   torch
+nvidia-nccl-cu12==2.18.1
+    # via torch
+nvidia-nvjitlink-cu12==12.3.101
+    # via
+    #   nvidia-cusolver-cu12
+    #   nvidia-cusparse-cu12
+nvidia-nvtx-cu12==12.1.105
+    # via torch
 oauthlib==3.2.2
     # via requests-oauthlib
 opt-einsum==3.3.0
@@ -757,6 +787,8 @@ traitlets==5.14.0
     #   nbclient
     #   nbconvert
     #   nbformat
+triton==2.1.0
+    # via torch
 trove-classifiers==2023.11.29
     # via validate-pyproject
 types-pkg-resources==0.1.3

--- a/requirements/dev_3.11.txt
+++ b/requirements/dev_3.11.txt
@@ -23,8 +23,6 @@ anndata==0.10.3
     #   scvi-tools
 anyio==4.2.0
     # via jupyter-server
-appnope==0.1.3
-    # via ipykernel
 argon2-cffi==23.1.0
     # via jupyter-server
 argon2-cffi-bindings==21.2.0
@@ -120,6 +118,7 @@ filelock==3.13.1
     # via
     #   torch
     #   tox
+    #   triton
     #   virtualenv
 flake8==6.1.0
     # via efaar_benchmarking (pyproject.toml)
@@ -414,6 +413,37 @@ numpy==1.26.2
     #   xarray
 numpyro==0.13.2
     # via scvi-tools
+nvidia-cublas-cu12==12.1.3.1
+    # via
+    #   nvidia-cudnn-cu12
+    #   nvidia-cusolver-cu12
+    #   torch
+nvidia-cuda-cupti-cu12==12.1.105
+    # via torch
+nvidia-cuda-nvrtc-cu12==12.1.105
+    # via torch
+nvidia-cuda-runtime-cu12==12.1.105
+    # via torch
+nvidia-cudnn-cu12==8.9.2.26
+    # via torch
+nvidia-cufft-cu12==11.0.2.54
+    # via torch
+nvidia-curand-cu12==10.3.2.106
+    # via torch
+nvidia-cusolver-cu12==11.4.5.107
+    # via torch
+nvidia-cusparse-cu12==12.1.0.106
+    # via
+    #   nvidia-cusolver-cu12
+    #   torch
+nvidia-nccl-cu12==2.18.1
+    # via torch
+nvidia-nvjitlink-cu12==12.3.101
+    # via
+    #   nvidia-cusolver-cu12
+    #   nvidia-cusparse-cu12
+nvidia-nvtx-cu12==12.1.105
+    # via torch
 oauthlib==3.2.2
     # via requests-oauthlib
 opt-einsum==3.3.0
@@ -738,6 +768,8 @@ traitlets==5.14.0
     #   nbclient
     #   nbconvert
     #   nbformat
+triton==2.1.0
+    # via torch
 trove-classifiers==2023.11.29
     # via validate-pyproject
 types-pkg-resources==0.1.3

--- a/requirements/dev_3.9.txt
+++ b/requirements/dev_3.9.txt
@@ -23,8 +23,6 @@ anndata==0.10.3
     #   scvi-tools
 anyio==4.2.0
     # via jupyter-server
-appnope==0.1.3
-    # via ipykernel
 argon2-cffi==23.1.0
     # via jupyter-server
 argon2-cffi-bindings==21.2.0
@@ -128,6 +126,7 @@ filelock==3.13.1
     # via
     #   torch
     #   tox
+    #   triton
     #   virtualenv
 flake8==6.1.0
     # via efaar_benchmarking (pyproject.toml)
@@ -434,6 +433,37 @@ numpy==1.26.2
     #   xarray
 numpyro==0.13.2
     # via scvi-tools
+nvidia-cublas-cu12==12.1.3.1
+    # via
+    #   nvidia-cudnn-cu12
+    #   nvidia-cusolver-cu12
+    #   torch
+nvidia-cuda-cupti-cu12==12.1.105
+    # via torch
+nvidia-cuda-nvrtc-cu12==12.1.105
+    # via torch
+nvidia-cuda-runtime-cu12==12.1.105
+    # via torch
+nvidia-cudnn-cu12==8.9.2.26
+    # via torch
+nvidia-cufft-cu12==11.0.2.54
+    # via torch
+nvidia-curand-cu12==10.3.2.106
+    # via torch
+nvidia-cusolver-cu12==11.4.5.107
+    # via torch
+nvidia-cusparse-cu12==12.1.0.106
+    # via
+    #   nvidia-cusolver-cu12
+    #   torch
+nvidia-nccl-cu12==2.18.1
+    # via torch
+nvidia-nvjitlink-cu12==12.3.101
+    # via
+    #   nvidia-cusolver-cu12
+    #   nvidia-cusparse-cu12
+nvidia-nvtx-cu12==12.1.105
+    # via torch
 oauthlib==3.2.2
     # via requests-oauthlib
 opt-einsum==3.3.0
@@ -769,6 +799,8 @@ traitlets==5.14.0
     #   nbclient
     #   nbconvert
     #   nbformat
+triton==2.1.0
+    # via torch
 trove-classifiers==2023.11.29
     # via validate-pyproject
 types-pkg-resources==0.1.3

--- a/requirements/main_3.10.txt
+++ b/requirements/main_3.10.txt
@@ -56,7 +56,9 @@ etils[epath,epy]==1.6.0
 exceptiongroup==1.2.0
     # via anndata
 filelock==3.13.1
-    # via torch
+    # via
+    #   torch
+    #   triton
 flax==0.7.5
     # via scvi-tools
 fonttools==4.47.0
@@ -245,6 +247,37 @@ numpy==1.26.2
     #   xarray
 numpyro==0.13.2
     # via scvi-tools
+nvidia-cublas-cu12==12.1.3.1
+    # via
+    #   nvidia-cudnn-cu12
+    #   nvidia-cusolver-cu12
+    #   torch
+nvidia-cuda-cupti-cu12==12.1.105
+    # via torch
+nvidia-cuda-nvrtc-cu12==12.1.105
+    # via torch
+nvidia-cuda-runtime-cu12==12.1.105
+    # via torch
+nvidia-cudnn-cu12==8.9.2.26
+    # via torch
+nvidia-cufft-cu12==11.0.2.54
+    # via torch
+nvidia-curand-cu12==10.3.2.106
+    # via torch
+nvidia-cusolver-cu12==11.4.5.107
+    # via torch
+nvidia-cusparse-cu12==12.1.0.106
+    # via
+    #   nvidia-cusolver-cu12
+    #   torch
+nvidia-nccl-cu12==2.18.1
+    # via torch
+nvidia-nvjitlink-cu12==12.3.101
+    # via
+    #   nvidia-cusolver-cu12
+    #   nvidia-cusparse-cu12
+nvidia-nvtx-cu12==12.1.105
+    # via torch
 oauthlib==3.2.2
     # via requests-oauthlib
 opt-einsum==3.3.0
@@ -422,6 +455,8 @@ tqdm==4.66.1
     #   scanpy
     #   scvi-tools
     #   umap-learn
+triton==2.1.0
+    # via torch
 typing-extensions==4.9.0
     # via
     #   chex

--- a/requirements/main_3.11.txt
+++ b/requirements/main_3.11.txt
@@ -52,7 +52,9 @@ docrep==0.3.2
 etils[epath,epy]==1.6.0
     # via orbax-checkpoint
 filelock==3.13.1
-    # via torch
+    # via
+    #   torch
+    #   triton
 flax==0.7.5
     # via scvi-tools
 fonttools==4.47.0
@@ -241,6 +243,37 @@ numpy==1.26.2
     #   xarray
 numpyro==0.13.2
     # via scvi-tools
+nvidia-cublas-cu12==12.1.3.1
+    # via
+    #   nvidia-cudnn-cu12
+    #   nvidia-cusolver-cu12
+    #   torch
+nvidia-cuda-cupti-cu12==12.1.105
+    # via torch
+nvidia-cuda-nvrtc-cu12==12.1.105
+    # via torch
+nvidia-cuda-runtime-cu12==12.1.105
+    # via torch
+nvidia-cudnn-cu12==8.9.2.26
+    # via torch
+nvidia-cufft-cu12==11.0.2.54
+    # via torch
+nvidia-curand-cu12==10.3.2.106
+    # via torch
+nvidia-cusolver-cu12==11.4.5.107
+    # via torch
+nvidia-cusparse-cu12==12.1.0.106
+    # via
+    #   nvidia-cusolver-cu12
+    #   torch
+nvidia-nccl-cu12==2.18.1
+    # via torch
+nvidia-nvjitlink-cu12==12.3.101
+    # via
+    #   nvidia-cusolver-cu12
+    #   nvidia-cusparse-cu12
+nvidia-nvtx-cu12==12.1.105
+    # via torch
 oauthlib==3.2.2
     # via requests-oauthlib
 opt-einsum==3.3.0
@@ -418,6 +451,8 @@ tqdm==4.66.1
     #   scanpy
     #   scvi-tools
     #   umap-learn
+triton==2.1.0
+    # via torch
 typing-extensions==4.9.0
     # via
     #   chex

--- a/requirements/main_3.9.txt
+++ b/requirements/main_3.9.txt
@@ -56,7 +56,9 @@ etils[epath,epy]==1.5.2
 exceptiongroup==1.2.0
     # via anndata
 filelock==3.13.1
-    # via torch
+    # via
+    #   torch
+    #   triton
 flax==0.7.5
     # via scvi-tools
 fonttools==4.47.0
@@ -68,7 +70,6 @@ frozenlist==1.4.1
 fsspec[http]==2023.12.2
     # via
     #   efaar_benchmarking (pyproject.toml)
-    #   etils
     #   gcsfs
     #   lightning
     #   pytorch-lightning
@@ -120,9 +121,7 @@ imageio==2.33.1
 importlib-metadata==7.0.1
     # via jax
 importlib-resources==6.1.1
-    # via
-    #   etils
-    #   matplotlib
+    # via matplotlib
 jax==0.4.23
     # via
     #   chex
@@ -251,6 +250,37 @@ numpy==1.26.2
     #   xarray
 numpyro==0.13.2
     # via scvi-tools
+nvidia-cublas-cu12==12.1.3.1
+    # via
+    #   nvidia-cudnn-cu12
+    #   nvidia-cusolver-cu12
+    #   torch
+nvidia-cuda-cupti-cu12==12.1.105
+    # via torch
+nvidia-cuda-nvrtc-cu12==12.1.105
+    # via torch
+nvidia-cuda-runtime-cu12==12.1.105
+    # via torch
+nvidia-cudnn-cu12==8.9.2.26
+    # via torch
+nvidia-cufft-cu12==11.0.2.54
+    # via torch
+nvidia-curand-cu12==10.3.2.106
+    # via torch
+nvidia-cusolver-cu12==11.4.5.107
+    # via torch
+nvidia-cusparse-cu12==12.1.0.106
+    # via
+    #   nvidia-cusolver-cu12
+    #   torch
+nvidia-nccl-cu12==2.18.1
+    # via torch
+nvidia-nvjitlink-cu12==12.3.101
+    # via
+    #   nvidia-cusolver-cu12
+    #   nvidia-cusparse-cu12
+nvidia-nvtx-cu12==12.1.105
+    # via torch
 oauthlib==3.2.2
     # via requests-oauthlib
 opt-einsum==3.3.0
@@ -297,7 +327,6 @@ pillow==10.2.0
 protobuf==4.25.1
     # via
     #   google-api-core
-    #   googleapis-common-protos
     #   orbax-checkpoint
 pyarrow==14.0.2
     # via efaar_benchmarking (pyproject.toml)
@@ -428,11 +457,12 @@ tqdm==4.66.1
     #   scanpy
     #   scvi-tools
     #   umap-learn
+triton==2.1.0
+    # via torch
 typing-extensions==4.9.0
     # via
     #   aioitertools
     #   chex
-    #   etils
     #   flax
     #   lightning
     #   lightning-utilities
@@ -457,7 +487,6 @@ yarl==1.9.4
     # via aiohttp
 zipp==3.17.0
     # via
-    #   etils
     #   importlib-metadata
     #   importlib-resources
 


### PR DESCRIPTION
# What?
lock dependencies
# Why?
Monthly maintenace
# Notes:
```

cc: @recursionpharma/rxrx-python

python
	 version: 3.9.14
	location: /usr/local/bin/python
roadie
	 version: 6.4.1
	location: /usr/local/lib/python3.9/site-packages/roadie
✓ Retrieving roadie-enabled Python interpreters
Found roadie for the following Python versions: 3.7, 3.8, 3.9, 3.10, 3.11
✓ Attempting to lock for Python 3.9
✓ Attempting to lock for Python 3.10
Skipping Python 3.7
Skipping Python 3.8
✓ Attempting to lock for Python 3.11

```