### PR TITLE
chore: Delete VERSION

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,0 @@
-MAJOR="1"
-MINOR="0"


### PR DESCRIPTION
# What?

-   Delete the legacy `VERSION` file from repository

# Why?

-   This file was used for internal publication. With the way we are using Github Actions, this file is unnecessary and only serves as a misdirection to the actual published version which is now controlled by explicit tagging.
