### PR TITLE
added filter for truth annotations to support CellProfiler benchmarking

### DIFF
--- a/efaar_benchmarking/benchmarking.py
+++ b/efaar_benchmarking/benchmarking.py
@@ -911,6 +911,11 @@ def compound_gene_benchmark(
     """
     config = config or BenchmarkConfig()
     truth = truth_data if truth_data is not None else load_truth_data(benchmark_data_dir)
+    print(f"shape of original annotations {truth.shape}")
+    # filter truth relationships for genes & compounds in [filtered] metadata
+    truth = truth[truth.gene_symbol.isin(map_data.metadata.perturbation) & 
+                  truth.treatment.isin(map_data.metadata.perturbation)]
+    print(f"shape of filteredgit annotations {truth.shape}")              
     similarities = compute_similarities(truth, map_data, pert_col, randomize=check_random)
 
     thresholds = (activity_threshold, inactivity_threshold)

--- a/efaar_benchmarking/benchmarking.py
+++ b/efaar_benchmarking/benchmarking.py
@@ -911,11 +911,10 @@ def compound_gene_benchmark(
     """
     config = config or BenchmarkConfig()
     truth = truth_data if truth_data is not None else load_truth_data(benchmark_data_dir)
-    print(f"shape of original annotations {truth.shape}")
     # filter truth relationships for genes & compounds in [filtered] metadata
-    truth = truth[truth.gene_symbol.isin(map_data.metadata.perturbation) & 
-                  truth.treatment.isin(map_data.metadata.perturbation)]
-    print(f"shape of filteredgit annotations {truth.shape}")              
+    truth = truth[
+        truth.gene_symbol.isin(map_data.metadata.perturbation) & truth.treatment.isin(map_data.metadata.perturbation)
+    ]
     similarities = compute_similarities(truth, map_data, pert_col, randomize=check_random)
 
     thresholds = (activity_threshold, inactivity_threshold)


### PR DESCRIPTION
# What?

-  added line to filter `gene_symbol` and `treatment` from the `truth` dataframe to only whats in the `map_data.metadata.perturbation` column

# Why?

-   Unfortunately our CellProfiler processing is missing a bunch of wells from the original dataset, so we need to apply these filters. Some stats:

```
CellProfiler_filter has 184,492 out of 222,601 original wells
CellProfiler_filter has 2080 out of 2921 relationships - missing 841 relationships
CellProfiler_filter has 1190 of 1674 compounds
CellProfiler_filter has 721 of 736 genes
```