### PR TITLE
chore: switch sourcing Python packages from Nexus to GAR

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 minversion = 3.11.0
 envlist = py3{11}, report, style
+requires = keyrings.google-artifactregistry-auth
 
 [testenv]
 commands =
@@ -27,3 +28,4 @@ commands =
 basepython = python3.11
 skip_install = true
 commands = pre-commit run --all-files --show-diff-on-failure
+


### PR DESCRIPTION
update from `legion` on behalf of @dmaljovec

# What?
 - Switch from Nexus to Google Artifact Registry for installing dependencies in test environments for this project
# Why?
 - We are trying to deprecate usage of Nexus