### PR TITLE
filter out compounds from gene-gene relationship benchmark

### DIFF
--- a/RxRx3-core_benchmarks/rxrx3_core_benchmarks_openphenom.ipynb
+++ b/RxRx3-core_benchmarks/rxrx3_core_benchmarks_openphenom.ipynb
@@ -44,7 +44,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -63,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,7 +85,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -118,7 +118,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/RxRx3-core_benchmarks/rxrx3_core_benchmarks_openphenom.ipynb
+++ b/RxRx3-core_benchmarks/rxrx3_core_benchmarks_openphenom.ipynb
@@ -44,7 +44,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -63,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,12 +72,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
     "embeddings_mrged = rxrx3_metadata.merge(\n",
-    "    openphenom_embeddings.rename(columns={\"well_id\": \"external_well_id\"}).groupby(\"external_well_id\").mean(), \n",
+    "    openphenom_embeddings.groupby(\"well_id\").mean(), \n",
     "    left_on=\"well_id\", \n",
     "    right_index=True,\n",
     ")"
@@ -85,7 +85,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -118,7 +118,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -152,12 +152,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "map_data_gene_only =  map_data.query(\"perturbation_type == 'CRISPR'\")  # only use CRISPR perturbations for gene-gene benchmarks\n",
+    "\n",
     "pert_signal_pval_cutoff = 0.05\n",
     "recall_thr_pairs = [(0.05, 0.95)]\n",
     "\n",
     "print(\"Computing recall...\")\n",
     "bmdb_metrics = known_relationship_benchmark(\n",
-    "    Bunch(metadata=map_data[metadata_cols], features=map_data[features_cols]),\n",
+    "    Bunch(metadata=map_data_gene_only[metadata_cols], features=map_data_gene_only[features_cols]),\n",
     "    recall_thr_pairs=recall_thr_pairs,\n",
     "    pert_col=pert_colname,\n",
     "    log_stats=True,\n",
@@ -309,6 +311,13 @@
     "\n",
     "    fig.show()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -327,7 +336,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
 A few users have pointed out that compounds are included in the gene-gene recall metric. This PR filters compounds out of the dataframe before computing the `known_relationship_benchmark`

Thanks Luke Nightingale (@LukeOZN) for pointing this out! 


