### PR TITLE
Ensure consistent list order is used for negative sampling function in compound-gene benchmark.

### DIFF
--- a/efaar_benchmarking/benchmarking.py
+++ b/efaar_benchmarking/benchmarking.py
@@ -789,7 +789,7 @@ def sample_for_item(
     if len(eligibles) < n_negatives:
         return np.array([]), np.array([])
 
-    negatives = rng.choice(list(eligibles), n_negatives, replace=False)
+    negatives = rng.choice(sorted(list(eligibles)), n_negatives, replace=False)
     items = np.concatenate([actives, negatives])
     labels = np.isin(items, actives).astype(int)
 


### PR DESCRIPTION
On converting the set to a list, no order is guaranteed, so a different list can be presented for sampling. This leads to slight differences in results on restarting python. The issue is fairly easy to reproduce by restarting the jupyter kernel and rerunning evaluation code.

This is fixed by sorting the list before sampling.
